### PR TITLE
feat: ejemplos para testing de queries de APIs Graphql

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
     </a>
 </p>
 
-# API Test Automation - Karate DSL
+# API Test Automation - Karate DSL For Restful and GraphQL APIs
 ## Starter project creado en vivo en stream de Twitch de [@CharlyAutomatiza](https://www.twitch.tv/charlyautomatiza) basado en [Karate DSL](https://karatelabs.github.io/karate/).
 
 ### Requerimientos generales
@@ -29,10 +29,19 @@ Descargar e instalar
 
     mvn clean test
 
-Para ejecutar un test específico, por ejemplo del feature [users.feature](src/test/java/examples/users/users.feature) aquellos casos con el tag **@create_user**.
+Para ejecutar un test específico de API Rest, por ejemplo del feature [users.feature](src/test/java/examples/users/users.feature) aquellos casos con el tag **@create_user**.
 
-    mvn test "-Dkarate.options=--tags @create_user"
+    mvn clean test "-Dkarate.options=--tags @create_user"
 
+Para ejecutar un test específico de API GraphQL, por ejemplo del feature [users-gql.feature](src/test/java/examples/usersgql/users-gql.feature) aquellos casos con el tag **@graphql_examples**.
+
+    mvn clean test "-Dkarate.options=--tags @graphql_examples"
+
+Para ejecutar todos los tests tanto de API Rest como de GraphQL se puede ejecutar con el tag **@run**.
+
+    mvn clean test "-Dkarate.options=--tags @run"
+
+**Importante**: Se agrega un test fallido para tener ejemplo de como se visualizan los errores en el reporte.
 
 **El reporte unificado de los resultados de los test**
 

--- a/src/test/java/examples/usersgql/UsersGqlRunner.java
+++ b/src/test/java/examples/usersgql/UsersGqlRunner.java
@@ -1,0 +1,12 @@
+package examples.usersgql;
+
+import com.intuit.karate.junit5.Karate;
+
+class UsersRunner {
+
+    @Karate.Test
+    Karate testUsers() {
+        return Karate.run("usersgql").relativeTo(getClass());
+    }
+
+}

--- a/src/test/java/examples/usersgql/queries/user-by-id.graphql
+++ b/src/test/java/examples/usersgql/queries/user-by-id.graphql
@@ -1,0 +1,13 @@
+query ($id: ID!){
+  user(id: $id) {
+    id
+    username
+    email
+    address {
+      geo {
+        lat
+        lng
+      }
+    }
+  }
+}

--- a/src/test/java/examples/usersgql/users-gql.feature
+++ b/src/test/java/examples/usersgql/users-gql.feature
@@ -1,0 +1,56 @@
+@graphql_examples @run
+Feature: users
+
+Background:
+* url 'https://graphqlzero.almansi.me/api'
+# this live url should work if you want to try this on your own
+
+@graphql_zero
+Scenario: simple graphql request
+    # note the use of text instead of def since this is NOT json
+    Given text query =
+    """
+    {
+      user(id: 1) {
+        posts {
+          data {
+            id
+            title
+          }
+        }
+      }
+    }
+    """
+    And request { query: '#(query)' }
+    When method post
+    Then status 200
+
+    # pretty print the response
+    * print 'response:', response
+
+    # json-path makes it easy to focus only on the parts you are interested in
+    # which is especially useful for graph-ql as responses tend to be heavily nested
+    # '$' happens to be a JsonPath-friendly short-cut for the 'response' variable
+    * match $.data.user.posts.data[0] contains { id: '1' }
+
+    # the '..' wildcard is useful for traversing deeply nested parts of the json
+    * def posts = $..posts.data[*]
+    * match posts[1] == { id: '2', title: 'qui est esse' }
+
+@graphql_zero
+Scenario Outline: graphql query from a file and using examples - <username>
+    # here the query is read from a file
+    # note that the 'replace' keyword (not used here) can also be very useful for dynamic query building
+    Given def query = read('./queries/user-by-id.graphql')
+    And request { query: '#(query)', variables: '#(<variables>)' }
+    When method post
+    Then status 200
+    And match response..username contains "<username>"
+    And match response.data.user.address == <address>
+
+Examples:
+    # The third example has the wrong "lng" field only for testing purposes
+    | variables | username  | address                                |
+    | { id: 1 } | Bret      | { geo:{ lng: 81.1496, lat: -37.3159 } }|
+    | { id: 2 } | Antonette | { geo:{ lat:-43.9509, lng: -34.4618 } }|
+    | { id: 3 } | Samantha  | { geo:{ lat:-68.6102, lng: -34.4618 } }|


### PR DESCRIPTION
- Nuevos ejemplos para testing de queries de APIs GraphQL usando:
 * Query fija en el mismo .feature file.
 * Query paramétrica en archivo .graphql para reutilizar una misma prueba con diferentes datos.